### PR TITLE
fix(error): Fix error crashing Hera

### DIFF
--- a/src/lib/giantbomb.js
+++ b/src/lib/giantbomb.js
@@ -101,7 +101,7 @@ gb.prototype.getAll = function(resource, opts, cb) {
         flow.push(function(_cb) {
           // make a request, push the results to the batch
           _this[resource]("", opts, function(err, resultSet) {
-            _.each(resultSet.results, function(val) {
+            _.each((resultSet && resultSet.results) || [], function(val) {
               batchedResults.push(val);
             });
 


### PR DESCRIPTION
Hera crashes with the following errors a LOT:

```/app/node_modules/node-giantbomb/src/lib/giantbomb.js:104
            _.each(resultSet.results, function(val) {
                            ^

TypeError: Cannot read property 'results' of undefined
    at /app/node_modules/node-giantbomb/src/lib/giantbomb.js:104:29
    at Request._callback (/app/node_modules/node-giantbomb/src/lib/utils.js:22:7)
    at Request.self.callback (/app/node_modules/request/request.js:199:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/app/node_modules/request/request.js:1036:10)
    at emitOne (events.js:101:20)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/app/node_modules/request/request.js:963:12)
    at emitNone (events.js:91:20)```